### PR TITLE
fix `package-osx` npm run command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm start
 
 # Package for specific OS
 $ npm run package-linux
-$ npm run package-darwin
+$ npm run package-osx
 $ npm run package-win32
 
 # Package for all OSs


### PR DESCRIPTION
This fixes a typo in README:

instead of running:
```bash
npm run package-darwin
```
one supposed to run 
```bash
npm run package-osx
```
as `package.json` does not contain `package-darwin` script