### PR TITLE
fix Unsupported platform osx for electron-packager

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "package-all": "npm run package-linux && npm run package-win32 && npm run package-darwin",
     "package-linux": "electron-packager ./ Lumenaire --platform=linux --arch=x64 --out=build",
     "package-win32": "electron-packager ./ Lumenaire --platform=win32 --arch=x64 --out=build",
-    "package-osx": "electron-packager ./ Lumenaire --platform=osx --arch=x64 --out=build"
+    "package-osx": "electron-packager ./ Lumenaire --platform=darwin --arch=x64 --out=build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
this is the error `electron-packager` produces:
```
$ npm run package-osx
> lumenaire@0.0.0 package-osx /Users/atsatsin/w/lumenaire
> electron-packager ./ Lumenaire --platform=osx --arch=x64 --out=build
Unsupported platform osx; must be one of: darwin, linux, mas, win32
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! lumenaire@0.0.0 package-osx: `electron-packager ./ Lumenaire --platform=osx --arch=x64 --out=build`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the lumenaire@0.0.0 package-osx script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/user/.npm/_logs/2018-03-28T07_30_13_744Z-debug.log
```