### PR TITLE
fix package-all command for npm run

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "electron main.js",
-    "package-all": "npm run package-linux && npm run package-win32 && npm run package-darwin",
+    "package-all": "npm run package-linux && npm run package-win32 && npm run package-osx",
     "package-linux": "electron-packager ./ Lumenaire --platform=linux --arch=x64 --out=build",
     "package-win32": "electron-packager ./ Lumenaire --platform=win32 --arch=x64 --out=build",
     "package-osx": "electron-packager ./ Lumenaire --platform=osx --arch=x64 --out=build"


### PR DESCRIPTION
this fixes `npm run package-all` command that now runs proper `package-osx` script for osx platform